### PR TITLE
ENH: Remove HTML and Liquid comments from `index.md`

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,10 +37,6 @@ _Note: All of this may sound complicated, but we'll explain things step-by-step 
 ![course_flow](fig/index/Course_flow_0.png)
 
 
-<!-- this is an html comment -->
-
-{% comment %} This is a comment in Liquid {% endcomment %}
-
 > ## Prerequisites
 > Attendees must have some base familiarity with Python and NIfTI images in order to comfortably progress through the lesson
 {: .prereq}


### PR DESCRIPTION
Remove HTML and Liquid comments from `index.md`.

The Liquid comment is visible in the new Workbench infrastructure index page. None of these comments are necessary, and were present since the very first commit (7ce7ba7), as they were present in the default contents of the `index.md` file in the legacy Carpentries infrastructure files.