### PR TITLE
DOC: Add `CITATION.cff` file

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,1 +1,0 @@
-FIXME: describe how to cite this lesson.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,45 @@
+cff-version: 1.2.0
+title: >-
+  Introduction to sMRI (Pre)processing and Analysis in
+  Python
+message: >-
+  Please cite this lesson using the information in this file
+  when you refer to it in publications, and/or if you
+  re-use, adapt, or expand on the content in your own
+  training material.
+type: dataset
+authors:
+  - given-names: Nikhil
+    affiliation: McGill University
+    family-names: Bhagwat
+    orcid: 'https://orcid.org/0000-0001-6073-7141'
+  - given-names: Michael
+    family-names: Dayan
+    orcid: 'https://orcid.org/0000-0002-2666-0969'
+    affiliation: Fondation Campus Biotech Geneva
+  - given-names: Erin W.
+    family-names: Dickie
+    orcid: 'https://orcid.org/0000-0003-3028-9864'
+    affiliation: >-
+      Krembil Centre for Neuroinformatics, Centre for
+      Addiction and Mental Health
+  - given-names: Toby
+    family-names: Hodges
+    orcid: 'https://orcid.org/0000-0003-1766-456X'
+    affiliation: The Carpentries
+  - given-names: Jon Haitz
+    family-names: Legarreta Gorroño
+    orcid: 'https://orcid.org/0000-0002-9661-1396'
+    affiliation: Université de Sherbrooke
+  - orcid: 'https://orcid.org/0000-0002-9794-749X'
+    given-names: Jean-Baptiste
+    family-names: Poline
+    affiliation: McGill University
+  - given-names: Swapna
+    family-names: Premasiri
+    affiliation: McGill University
+  - given-names: David J.
+    family-names: Rotenberg
+    affiliation: >-
+      Krembil Centre for Neuroinformatics, Centre for
+      Addiction and Mental Health


### PR DESCRIPTION
Add `CITATION.cff` file. Remove the existing empty `CITATION` file.

Documentation:
https://carpentries.org/blog/2025/12/cite-this-lesson-pages/#cite-this-lesson-pages https://carpentries.github.io/sandpaper-docs/editing.html#making-your-lesson-citable